### PR TITLE
Add API for passing around project for bucketing in context

### DIFF
--- a/bucketing.go
+++ b/bucketing.go
@@ -104,12 +104,12 @@ func (e Experiment) findBucket(bucketValue int) *Variation {
 // and the given user ID. The project from which to generate the variations
 // is loaded from the provided context object. See Project.ToContext for
 // more details.
-func GetVariation(ctx context.Context, experimentName, userID string) *Impression {
+func GetVariation(ctx context.Context, experimentName string) *Impression {
 	projectCtx, ok := ctx.Value(projCtxKey).(*projectContext)
 	if !ok {
 		return nil
 	}
-	impression := projectCtx.GetVariation(experimentName, userID)
+	impression := projectCtx.GetVariation(experimentName, projectCtx.userID)
 	if impression == nil {
 		return nil
 	}

--- a/bucketing_test.go
+++ b/bucketing_test.go
@@ -201,10 +201,10 @@ func TestProject_GetVariation(t *testing.T) {
 
 func TestGetVariation(t *testing.T) {
 	tests := []struct {
-		name                   string
-		ctx                    context.Context
-		experimentName, userID string
-		expectedImpression     *Impression
+		name               string
+		ctx                context.Context
+		experimentName     string
+		expectedImpression *Impression
 	}{
 		{
 			"impression returned from project stored in context",
@@ -216,29 +216,26 @@ func TestGetVariation(t *testing.T) {
 							"user": {id: "abc", Key: "abc"},
 						},
 					},
-				}}.ToContext(context.Background()),
+				}}.ToContext(context.Background(), "user"),
 			"a",
-			"user",
 			&Impression{Variation: Variation{id: "abc", Key: "abc"}, UserID: "user"},
 		}, {
 			"no project stored in context returns nil",
 			context.Background(),
-			"",
 			"",
 			nil,
 		}, {
 			"nil variation returns nil",
 			Project{experiments: map[string]Experiment{
 				"a": {status: "disabled"},
-			}}.ToContext(context.Background()),
-			"",
+			}}.ToContext(context.Background(), "user"),
 			"",
 			nil,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetVariation(test.ctx, test.experimentName, test.userID)
+			result := GetVariation(test.ctx, test.experimentName)
 			assertImpressionEqual(t, test.expectedImpression, result)
 			if result != nil {
 				assert.Contains(t, test.ctx.Value(projCtxKey).(*projectContext).impressions, *result)

--- a/bucketing_test.go
+++ b/bucketing_test.go
@@ -15,6 +15,7 @@
 package optimizely
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -57,6 +58,17 @@ func TestExperiment_getBucketValue(t *testing.T) {
 			assert.Equal(t, test.expectedValue, Experiment{id: test.experimentID}.getBucketValue(test.bucketingID))
 		})
 	}
+}
+
+func assertImpressionEqual(t *testing.T, expected, actual *Impression) {
+	if actual != nil {
+		// make sure that the result timestamp is plausible, then overwrite with the zero time to
+		// assert the rest of the result struct is valid
+		now := time.Now()
+		assert.InDelta(t, now.Nanosecond(), actual.Timestamp.Nanosecond(), float64(100*time.Millisecond))
+		expected.Timestamp = actual.Timestamp
+	}
+	assert.Equal(t, expected, actual)
 }
 
 func TestExperiment_findBucket(t *testing.T) {
@@ -105,7 +117,7 @@ func TestProject_GetVariation(t *testing.T) {
 		name                   string
 		project                Project
 		experimentName, userID string
-		expectedVariation      *Impression
+		expectedImpression     *Impression
 		shouldCache            bool
 	}{
 		{
@@ -179,16 +191,57 @@ func TestProject_GetVariation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.project.GetVariation(test.experimentName, test.userID)
-			if result != nil {
-				// make sure that the result timestamp is plausible, then overwrite with the zero time to
-				// assert the rest of the result struct is valid
-				now := time.Now()
-				assert.InDelta(t, now.Nanosecond(), result.Timestamp.Nanosecond(), float64(100*time.Millisecond))
-				result.Timestamp = time.Time{}
-			}
-			assert.Equal(t, test.expectedVariation, result)
+			assertImpressionEqual(t, test.expectedImpression, result)
 			if test.shouldCache {
 				assert.Contains(t, test.project.experiments[test.experimentName].cachedVariations, test.userID)
+			}
+		})
+	}
+}
+
+func TestGetVariation(t *testing.T) {
+	tests := []struct {
+		name                   string
+		ctx                    context.Context
+		experimentName, userID string
+		expectedImpression     *Impression
+	}{
+		{
+			"impression returned from project stored in context",
+			Project{
+				experiments: map[string]Experiment{
+					"a": {
+						status: runningStatus,
+						forcedVariations: map[string]Variation{
+							"user": {id: "abc", Key: "abc"},
+						},
+					},
+				}}.ToContext(context.Background()),
+			"a",
+			"user",
+			&Impression{Variation: Variation{id: "abc", Key: "abc"}, UserID: "user"},
+		}, {
+			"no project stored in context returns nil",
+			context.Background(),
+			"",
+			"",
+			nil,
+		}, {
+			"nil variation returns nil",
+			Project{experiments: map[string]Experiment{
+				"a": {status: "disabled"},
+			}}.ToContext(context.Background()),
+			"",
+			"",
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := GetVariation(test.ctx, test.experimentName, test.userID)
+			assertImpressionEqual(t, test.expectedImpression, result)
+			if result != nil {
+				assert.Contains(t, test.ctx.Value(projCtxKey).(*projectContext).impressions, *result)
 			}
 		})
 	}

--- a/event.go
+++ b/event.go
@@ -182,9 +182,6 @@ func EventsFromContext(ctx context.Context, options ...func(*Events) error) *Eve
 	if len(projectCtx.impressions) == 0 {
 		return nil
 	}
-	//if options == nil {
-	//	options = make([]func(*Events) error, 0, len(projectCtx.impressions))
-	//}
 	for _, impression := range projectCtx.impressions {
 		options = append(options, ActivatedImpression(impression))
 	}

--- a/event.go
+++ b/event.go
@@ -15,6 +15,7 @@
 package optimizely
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -91,14 +92,14 @@ func NewEvents(options ...func(*Events) error) (Events, error) {
 // ActivatedImpression adds the variation impression to the set of reported events. Note that
 // while many impressions can be added as events, each impression must have originated from
 // the same Optimizely account or an error will be returned while creating the events.
-func ActivatedImpression(v Impression) func(*Events) error {
+func ActivatedImpression(i Impression) func(*Events) error {
 	return func(e *Events) error {
 		if e.AccountID == "" {
-			e.AccountID = v.experiment.project.AccountID
-		} else if e.AccountID != v.experiment.project.AccountID {
+			e.AccountID = i.experiment.project.AccountID
+		} else if e.AccountID != i.experiment.project.AccountID {
 			return fmt.Errorf("activated variations must all be in the same account")
 		}
-		e.Visitors = append(e.Visitors, v.toVisitor())
+		e.Visitors = append(e.Visitors, i.toVisitor())
 		return nil
 	}
 }
@@ -161,4 +162,48 @@ func (v Impression) toVisitor() visitor {
 			Events:    []event{ev},
 		}},
 	}
+}
+
+// EventsFromContext creates Events from all the impressions that were seen
+// during the lifecycle of the provided context. If no impressions were seen
+// or no project was found in the provided context, nil is returned.
+// The options provided to this function match the options provided to
+// NewEvents with the exception that the ActivatedImpression function
+// should never be provided as an option and may result in a panic if
+// the provided impression was created by a project in a different account from
+// the project stored in the context.
+func EventsFromContext(ctx context.Context, options ...func(*Events) error) *Events {
+	projectCtx, ok := ctx.Value(projCtxKey).(*projectContext)
+	if !ok {
+		return nil
+	}
+	projectCtx.mutex.Lock()
+	defer projectCtx.mutex.Unlock()
+	if len(projectCtx.impressions) == 0 {
+		return nil
+	}
+	//if options == nil {
+	//	options = make([]func(*Events) error, 0, len(projectCtx.impressions))
+	//}
+	for _, impression := range projectCtx.impressions {
+		options = append(options, ActivatedImpression(impression))
+	}
+	// There can never be an error here when this API is used correctly because
+	// there are only two cases that can cause an error: no impressions, and
+	// impressions from different projects. We know that there are impressions
+	// because the case of no impressions is handled above, and we know that all
+	// impressions are from the same project because they had to be inserted
+	// into the context by the same project. Thus, the only way an error
+	// can occur here is if the API is misused and an impression from
+	// a different project was passed as an additional option to this
+	// function.
+	events, err := NewEvents(options...)
+	if err != nil {
+		panic(err)
+	}
+
+	// reset impressions in case the project context gets reused
+	projectCtx.impressions = make([]Impression, 0)
+
+	return &events
 }

--- a/event_test.go
+++ b/event_test.go
@@ -294,11 +294,20 @@ func TestEventsFromContext(t *testing.T) {
 			},
 			nil,
 			true,
+		}, {
+			"no project in context returns nil",
+			nil,
+			[]func(*Events) error{},
+			nil,
+			false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.WithValue(context.Background(), projCtxKey, test.projectCtx)
+			ctx := context.Background()
+			if test.projectCtx != nil {
+				ctx = context.WithValue(ctx, projCtxKey, test.projectCtx)
+			}
 			if test.expectPanic {
 				assert.Panics(t, func() { EventsFromContext(ctx, test.options...) })
 				return

--- a/event_test.go
+++ b/event_test.go
@@ -15,6 +15,7 @@
 package optimizely
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -39,6 +40,18 @@ func assertVisitorEqual(t *testing.T, expected, actual visitor) {
 		}
 	}
 	assert.Equal(t, expected, actual)
+}
+
+func assertEventsEqual(t *testing.T, expected, actual Events) {
+	assert.Equal(t, expected.AccountID, actual.AccountID)
+	assert.Equal(t, expected.AnonymizeIP, actual.AnonymizeIP)
+	assert.Equal(t, expected.ClientName, actual.ClientName)
+	assert.Equal(t, expected.ClientVersion, actual.ClientVersion)
+	assert.Equal(t, expected.EnrichDecisions, actual.EnrichDecisions)
+	assert.Equal(t, len(expected.Visitors), len(actual.Visitors))
+	for i := range expected.Visitors {
+		assertVisitorEqual(t, expected.Visitors[i], actual.Visitors[i])
+	}
 }
 
 func TestImpression_toVisitor(t *testing.T) {
@@ -230,15 +243,73 @@ func TestNewEvents(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedEvents.AccountID, events.AccountID)
-			assert.Equal(t, test.expectedEvents.AnonymizeIP, events.AnonymizeIP)
-			assert.Equal(t, test.expectedEvents.ClientName, events.ClientName)
-			assert.Equal(t, test.expectedEvents.ClientVersion, events.ClientVersion)
-			assert.Equal(t, test.expectedEvents.EnrichDecisions, events.EnrichDecisions)
-			assert.Equal(t, len(test.expectedEvents.Visitors), len(events.Visitors))
-			for i := range test.expectedEvents.Visitors {
-				assertVisitorEqual(t, test.expectedEvents.Visitors[i], events.Visitors[i])
+			assertEventsEqual(t, test.expectedEvents, events)
+		})
+	}
+}
+
+func TestEventsFromContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		projectCtx     *projectContext
+		options        []func(*Events) error
+		expectedEvents *Events
+		expectPanic    bool
+	}{
+		{
+			"events pulled from impressions in context",
+			&projectContext{
+				impressions: []Impression{{
+					Variation: Variation{experiment: &Experiment{project: &Project{}}},
+					Timestamp: time.Unix(0, 0),
+				}},
+			},
+			[]func(*Events) error{ClientName(""), AnonynmizeIP(false), EnrichDecisions(false)},
+			&Events{
+				Visitors: []visitor{{
+					Snapshots: []snapshot{{
+						Decisions: []decision{{}},
+						Events:    []event{{Type: "campaign_activated"}},
+					}},
+				}},
+			},
+			false,
+		}, {
+			"no impressions returns nil",
+			&projectContext{impressions: []Impression{}},
+			[]func(*Events) error{},
+			nil,
+			false,
+		}, {
+			"improper usage with additional recorded impression from another account panics",
+			&projectContext{
+				impressions: []Impression{{
+					Variation: Variation{experiment: &Experiment{project: &Project{AccountID: "account"}}},
+				}},
+			},
+			[]func(*Events) error{
+				ActivatedImpression(
+					Impression{Variation: Variation{experiment: &Experiment{project: &Project{AccountID: "account_2"}}}},
+				),
+			},
+			nil,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), projCtxKey, test.projectCtx)
+			if test.expectPanic {
+				assert.Panics(t, func() { EventsFromContext(ctx, test.options...) })
+				return
 			}
+			result := EventsFromContext(ctx, test.options...)
+			if test.expectedEvents == nil {
+				assert.Nil(t, result)
+				return
+			}
+			assertEventsEqual(t, *test.expectedEvents, *result)
+			assert.Len(t, test.projectCtx.impressions, 0)
 		})
 	}
 }

--- a/project.go
+++ b/project.go
@@ -179,21 +179,23 @@ const projCtxKey ctxKey = iota
 
 type projectContext struct {
 	Project
+	userID      string
 	impressions []Impression
 	mutex       sync.Mutex
 }
 
-// ToContext creates a context with the project as a value in the context.
-// By using GetVariation with the context returned from this method, not only
-// will each Impression be returned to the caller, but each Impression will
-// be recorded in the context. Once the lifecycle of the context is complete,
-// use EventsFromContext to create a unified Events object containing every
-// impression that occurred during the context's lifecycle. This provides
-// simplified API for bucketing users across multiple experiments and multiple
-// code-paths.
-func (p Project) ToContext(ctx context.Context) context.Context {
+// ToContext creates a context with the project as a value in the context for
+// a specific user ID. By using GetVariation with the context returned from
+// this method, not only will each Impression be returned to the caller, but
+// each Impression will be recorded in the context. Once the lifecycle of the
+// context is complete, use EventsFromContext to create a unified Events object
+// containing every impression that occurred during the context's lifecycle.
+// This provides simplified API for bucketing a user across multiple experiments
+// and multiple code-paths.
+func (p Project) ToContext(ctx context.Context, userID string) context.Context {
 	projectCtx := &projectContext{
 		Project:     p,
+		userID:      userID,
 		impressions: make([]Impression, 0),
 	}
 	return context.WithValue(ctx, projCtxKey, projectCtx)

--- a/project_test.go
+++ b/project_test.go
@@ -200,13 +200,14 @@ func TestNewProjectFromDataFile(t *testing.T) {
 
 func TestProject_ToContext(t *testing.T) {
 	p := Project{ProjectID: "id"}
-	ctx := p.ToContext(context.Background())
+	ctx := p.ToContext(context.Background(), "user")
 	projectCtx, ok := ctx.Value(projCtxKey).(*projectContext)
 	require.True(t, ok)
 	assert.Equal(
 		t,
 		&projectContext{
 			Project:     p,
+			userID:      "user",
 			impressions: []Impression{},
 		},
 		projectCtx,

--- a/project_test.go
+++ b/project_test.go
@@ -15,10 +15,12 @@
 package optimizely
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewProjectFromDataFile(t *testing.T) {
@@ -194,4 +196,19 @@ func TestNewProjectFromDataFile(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestProject_ToContext(t *testing.T) {
+	p := Project{ProjectID: "id"}
+	ctx := p.ToContext(context.Background())
+	projectCtx, ok := ctx.Value(projCtxKey).(*projectContext)
+	require.True(t, ok)
+	assert.Equal(
+		t,
+		&projectContext{
+			Project:     p,
+			impressions: []Impression{},
+		},
+		projectCtx,
+	)
 }


### PR DESCRIPTION
My idea with this PR is that you don't have to store and pass the instantiated `Project` object nor the user ID to every point in the application where you might want to bucket users nor do you need to keep track of each bucketing impression every time a user is bucketed. Instead, you can put a `Project` and user ID into a `context.Context`, pass the context around and use the context to bucket users. Then, at the end of a request, dump one big out the data structure with every bucketing impression that occurred. 

For example:

```go
func entrypoint(project optimizely.Project, userID string) {
    ctx := project.ToContext(context.Background(), userID)
    doSomethingThatMightBucket(ctx)
    doSomethingElseThatMightBucket(ctx)
    events := EventsFromContext(ctx)
    if events != nil {
        optimizely.ReportEvents(events)
    }

func doSomethingThatMightBucket(ctx context.Context) {
    variation := GetVariation(ctx, "experiment-1")
   // do something based on variation
}

func doSomethingElseThatMightBucket(ctx context.Context) {
    variation := GetVariation(ctx, "experiment-2")
   // do something based on variation
}
```