### PR TITLE
Correct module name for vcs

### DIFF
--- a/event.go
+++ b/event.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/spothero/optimizely-sdk-go/api"
 	"golang.org/x/xerrors"
-	"optimizely-sdk-go/api"
 )
 
 type event struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module optimizely-sdk-go
+module github.com/spothero/optimizely-sdk-go
 
 go 1.12
 


### PR DESCRIPTION
```
go get github.com/spothero/optimizely-sdk-go 
go: github.com/spothero/optimizely-sdk-go@v0.5.1: parsing go.mod: unexpected module path "optimizely-sdk-go"
go: error loading module requirements
```
Took me awhile to figure this out; pretty sure this is the issue... not a super helpful error message.
